### PR TITLE
(bug) correct task param in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In the Console, run the `healthcheck_lite::configure` task, targeting the Primar
 Or, from the command line of the Primary Master, run:
 
 ```bash
-puppet task run healthcheck_lite::configure --nodes $(facter -p certname)
+puppet task run healthcheck_lite::configure --nodes $(puppet config print certname)
 ```
 
 #### Task parameters
@@ -74,7 +74,7 @@ In the Console, run the `healthcheck_lite::collect` task, targeting the Primary 
 Or, from the command line of the Primary Master, run:
 
 ```bash
-puppet task run healthcheck_lite::collect --nodes $(facter -p certname)
+puppet task run healthcheck_lite::collect --nodes $(puppet config print certname)
 ```
 
 When finished, the `healthcheck_lite::collect` task will output a list of files.


### PR DESCRIPTION
Use 'puppet config print' instead of 'facter -p'